### PR TITLE
Configure Vercel build for Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Node.js dependencies
+node_modules/
+
+# Python virtual environments
+backend/.venv/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "climate-outlier-detection",
+  "private": true,
+  "scripts": {
+    "dev": "npm --prefix frontend2 run dev",
+    "build": "npm --prefix frontend2 run build",
+    "start": "npm --prefix frontend2 run start",
+    "lint": "npm --prefix frontend2 run lint",
+    "vercel-build": "cd frontend2 && npm ci && npm run build"
+  },
+  "devDependencies": {
+    "next": "15.5.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a repository-level package.json that proxies npm scripts to the Next.js frontend and exposes a vercel-build step
- include the Next.js dependency at the repository root so Vercel can detect the framework during builds
- add a root .gitignore to keep node_modules and Python virtual environments out of version control

## Testing
- npm install *(fails in sandbox: 403 Forbidden when fetching next)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa8c5a57483328f81d0bc333569a5