### PR TITLE
Fix Vercel build failure caused by remote font fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Node.js dependencies
+node_modules/
+
+# Python virtual environments
+backend/.venv/

--- a/frontend2/app/globals.css
+++ b/frontend2/app/globals.css
@@ -44,6 +44,10 @@
 }
 
 :root {
+  --font-geist-sans: "Inter", "Helvetica Neue", Helvetica, Arial, system-ui,
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-geist-mono: "Roboto Mono", "SFMono-Regular", ui-monospace, Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/frontend2/app/layout.js
+++ b/frontend2/app/layout.js
@@ -1,15 +1,4 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata = {
   title: "Create Next App",
@@ -19,11 +8,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/frontend2/package.json
+++ b/frontend2/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "climate-outlier-detection",
+  "private": true,
+  "scripts": {
+    "dev": "npm --prefix frontend2 run dev",
+    "build": "npm --prefix frontend2 run build",
+    "start": "npm --prefix frontend2 run start",
+    "lint": "npm --prefix frontend2 run lint",
+    "vercel-build": "cd frontend2 && npm ci && npm run build"
+  },
+  "devDependencies": {
+    "next": "15.5.3"
+  }
+}


### PR DESCRIPTION
## Summary
- stop using `next/font/google` in the app layout so the build no longer tries to download Google Fonts during compilation
- define Geist font CSS variables with bundled fallbacks to preserve styling without network requests
- switch the app scripts back to `next dev`/`next build` so production deploys use the stable webpack pipeline instead of Turbopack, avoiding the Tailwind/PostCSS crash on Vercel

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa8c5a57483328f81d0bc333569a5